### PR TITLE
Create initial HTMX chatbot frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Text Adventure Chatbot</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div id="chat-window">
+        <div id="chat-messages">
+            <div class="message bot-message">Welcome, brave adventurer! Your quest awaits. What is your first command?</div>
+            <!-- Messages will appear here -->
+        </div>
+        <div id="input-area">
+            <form id="chat-form" hx-post="/chat" hx-target="#chat-messages" hx-swap="beforeend" hx-on::after-request="this.reset()">
+                <input type="text" name="message" id="message-input" placeholder="Enter your command..." autofocus>
+                <button type="submit">Send</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,92 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    background-color: #f4f4f4;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+#chat-window {
+    width: 80%;
+    max-width: 600px;
+    height: 90vh;
+    max-height: 700px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+#chat-messages {
+    flex-grow: 1;
+    padding: 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.message {
+    padding: 10px 15px;
+    border-radius: 18px;
+    max-width: 70%;
+    line-height: 1.4;
+}
+
+.user-message {
+    background-color: #007bff;
+    color: white;
+    align-self: flex-end;
+    border-bottom-right-radius: 4px;
+}
+
+.bot-message {
+    background-color: #e9ecef;
+    color: #333;
+    align-self: flex-start;
+    border-bottom-left-radius: 4px;
+}
+
+#input-area {
+    border-top: 1px solid #ddd;
+    padding: 15px;
+    background-color: #f9f9f9;
+}
+
+#chat-form {
+    display: flex;
+}
+
+#message-input {
+    flex-grow: 1;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 20px;
+    margin-right: 10px;
+    font-size: 1em;
+}
+
+#message-input:focus {
+    outline: none;
+    border-color: #007bff;
+    box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+}
+
+#chat-form button {
+    padding: 10px 20px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    font-size: 1em;
+    transition: background-color 0.2s ease;
+}
+
+#chat-form button:hover {
+    background-color: #0056b3;
+}


### PR DESCRIPTION
This commit introduces the basic frontend structure for a text adventure chatbot using HTMX.

It includes:
- `index.html`: The main page with a chat display area, user input form, and HTMX integration for sending messages and displaying responses. An initial bot message is included.
- `style.css`: Basic styling for the chat interface, including distinct styles for user and bot messages.

The HTMX form is configured to POST to a `/chat` endpoint (which is currently a placeholder) and append the response to the chat messages div. The input field is cleared after each submission.